### PR TITLE
Fix async scheduler

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -1,7 +1,7 @@
 # scheduler.py
 from dotenv import load_dotenv
 import os, pathlib
-from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from telegram import Bot
 from database import get_random_word, get_test_words
 import logging
@@ -16,24 +16,24 @@ bot = Bot(token=TOKEN)
 logging.getLogger("apscheduler").setLevel(logging.DEBUG)
 
 # 3. задачи
-def send_word_daily():
+async def send_word_daily():
     logging.info("🔔 send_word_daily")
     w, t = get_random_word()
-    bot.send_message(chat_id=CHAT_ID,
-                     text=f"📘 Daily word:\n{w} – {t}")
+    await bot.send_message(chat_id=CHAT_ID,
+                           text=f"📘 Daily word:\n{w} – {t}")
 
-def send_weekly_test():
+async def send_weekly_test():
     logging.info("🔔 send_weekly_test")
     lst = get_test_words(5)
     msg = "📝 Weekly test:\n" + "\n".join(f"{i+1}. {w}" for i, w in enumerate(lst))
-    bot.send_message(chat_id=CHAT_ID, text=msg)
+    await bot.send_message(chat_id=CHAT_ID, text=msg)
 
 # 4. планировщик
 def setup_schedulers():
-    sched = BackgroundScheduler()
+    sched = AsyncIOScheduler()
     logging.info("⏰ scheduling daily word and weekly test")
-    # send daily word every day at 12:28
-    sched.add_job(send_word_daily, "cron", hour=12, minute=28)
+    # send daily word every day at 12:36 (for testing)
+    sched.add_job(send_word_daily, "cron", hour=12, minute=36)
     # send weekly test every Monday at 09:30
     sched.add_job(send_weekly_test, "cron", day_of_week="mon", hour=9, minute=30)
     sched.start()


### PR DESCRIPTION
## Summary
- use `AsyncIOScheduler` instead of `BackgroundScheduler`
- make scheduled tasks async and await bot message sending
- update daily notification time to 12:36 for testing

## Testing
- `python3 -m py_compile main.py scheduler.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ce21900c832eac12df85cf77795b